### PR TITLE
Dhouse/dart 57 - Refactoring current tests to run against Harvard DART

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ screenshots/
 __pycache__
 *.pyc
 envs/local.env
+.idea/
+.python-version

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,36 @@
+DART_DEV=https://dev.dart.harvard.edu
+DART_STAGE=https://stage.dart.harvard.edu
+
 dart_firefox:
-	behave -D instance_url=https://dart-test-stage.raccoongang.com -D browser=firefox projects/dart/features
+	behave -D instance_url=${DART_DEV} -D browser=firefox projects/dart/features
 
 dart_chrome:
-	behave -D instance_url=https://dart-test-stage.raccoongang.com -D browser=chrome projects/dart/features
+	behave -D instance_url=${DART_DEV} -D browser=chrome projects/dart/features
 
 dart_ie:
-	behave -D instance_url=https://dart-test-stage.raccoongang.com -D browser=ie projects/dart/features
+	behave -D instance_url=${DART_DEV} -D browser=ie projects/dart/features
 
 dart_edge:
-		behave -D instance_url=https://dart-test-stage.raccoongang.com -D browser=edge projects/dart/features
+		behave -D instance_url=${DART_DEV} -D browser=edge projects/dart/features
 
 dart_phantomjs:
-	behave -D instance_url=https://dart-test-stage.raccoongang.com -D browser=phantomjs projects/dart/features
+	behave -D instance_url=${DART_DEV} -D browser=phantomjs projects/dart/features
 
 dart_opera:
-	behave -D instance_url=https://dart-test-stage.raccoongang.com -D browser=opera projects/dart/features
+	behave -D instance_url=${DART_DEV} -D browser=opera projects/dart/features
 
 dart_safari:
-	behave -D instance_url=https://dart-test-stage.raccoongang.com -D browser=safari projects/dart/features
+	behave -D instance_url=${DART_DEV} -D browser=safari projects/dart/features
 
 dart:
 	make dart_chrome
 	make dart_firefox
 
 dart_docker:
-	behave -D instance_url=${STAGE_URL} -D browser=phantomjs -D docker projects/dart/features
+	behave -D instance_url=${DART_STAGE} -D browser=phantomjs -D docker projects/dart/features
 
 courselets_docker:
-	behave -D instance_url=${STAGE_URL} -D browser=phantomjs -D docker projects/courselets/features
+	behave -D instance_url=${DART_STAGE} -D browser=phantomjs -D docker projects/courselets/features
 
 
 dart_firefox_local:

--- a/projects/dart/features/environment.py
+++ b/projects/dart/features/environment.py
@@ -8,8 +8,14 @@ from webdriver_manager.microsoft import EdgeDriverManager, IEDriverManager
 from webdriver_manager.phantomjs import PhantomJsDriverManager
 
 
-BEHAVE_DEBUG_ON_ERROR = True
+BEHAVE_DEBUG_ON_ERROR = os.getenv('BEHAVE_PDB', '')
 WAIT = os.getenv('WAIT', 1)
+
+
+def before_all(context):
+    context.credentials = {
+        'login': 'moonmoon',
+    }
 
 
 def before_scenario(context, scenario):

--- a/projects/dart/features/pages/__init__.py
+++ b/projects/dart/features/pages/__init__.py
@@ -1,2 +1,3 @@
 from .main_page import MainPage
 from .browse_page import BrowsePage
+from .login_page import LoginPage

--- a/projects/dart/features/pages/common_page.py
+++ b/projects/dart/features/pages/common_page.py
@@ -8,6 +8,7 @@ class CommonPage:
     """
     def __init__(self, context):
         self.browser = context.browser
+        self.base_url = context.base_url
 
     def find(self, attr_name):
         el = self.browser.find_element_by_css_selector(

--- a/projects/dart/features/pages/login_page.py
+++ b/projects/dart/features/pages/login_page.py
@@ -1,0 +1,19 @@
+"""
+Generic login page
+"""
+from .common_page import CommonPage
+
+
+class LoginPage(CommonPage):
+    """
+    Login page, functional in local deployment without HarvardKey
+    """
+
+    def navigate(self):
+        self.browser.get(self.base_url+'/users/login/')
+
+    def login(self):
+        self.browser.find_element_by_css_selector('[type="submit"]').click()
+
+    def set_name(self, name='moon'):
+        self.browser.find_element_by_name('username').send_keys(name)

--- a/projects/dart/features/steps/login.py
+++ b/projects/dart/features/steps/login.py
@@ -1,5 +1,5 @@
 from behave import given
-
+from pages import LoginPage
 
 @given('an anonymous user')
 def step_impl(context):
@@ -8,10 +8,10 @@ def step_impl(context):
 
 @given('an logged in user')
 def step_impl(context):
-    br = context.browser
-    br.get(context.base_url+'/users/login/')
-    br.find_element_by_name('username').send_keys('dummy')
-    br.find_element_by_css_selector('[type="submit"]').click()
+    login_page = LoginPage(context)
+    login_page.navigate()
+    login_page.set_name(context.credentials['login'])
+    login_page.login()
 
 
 @then('I am redirected to the login page')


### PR DESCRIPTION
These changes make the behave tests runnable against Harvard DART by allowing pdb fall-through to be configurable with an environment variable. Additionally, some work was done to integrate the login page to the existing Page Object Model.